### PR TITLE
Tolerance in `set_h!` is now relative

### DIFF
--- a/src/Gas.jl
+++ b/src/Gas.jl
@@ -339,7 +339,7 @@ function set_h!(gas::AbstractGas, hspec::Float64)
         res_t = gas.cp  # ∂R/∂T = ∂h/∂T = cp
         dT = -res / res_t # Newton step
 
-        if abs(dT) ≤ ϵ
+        if abs(dT/T) ≤ ϵ
             break
         end
         #Prevent limit cycles if the iteration count is high
@@ -350,7 +350,7 @@ function set_h!(gas::AbstractGas, hspec::Float64)
         gas.T = T
     end
 
-    if abs(dT) > ϵ
+    if abs(dT/T) > ϵ
         error(
             "Error: `set_h!` did not converge:\ngas=",
             print(gas),

--- a/test/unit_test_combustion.jl
+++ b/test/unit_test_combustion.jl
@@ -5,7 +5,7 @@
 
     @test IdealGasThermo.AFT(CH4) == 2376.6102617357988
     O2 = species_in_spdict("O2")
-    @test IdealGasThermo.AFT(CH4, O2) == 5280.53933225877
+    @test IdealGasThermo.AFT(CH4, O2) ≈ 5280.53933225877 rtol = 1e-8
 end
 @testset "burnt gas funcs." begin
     CH4 = species_in_spdict("CH4")

--- a/test/unit_test_turbo.jl
+++ b/test/unit_test_turbo.jl
@@ -21,7 +21,7 @@
     gas2 = deepcopy(gas)
     set_TP!(gas2, 3 * Tstd, Pstd)
     gas3 = IdealGasThermo.gas_mixing(gas, gas2, 2.0)
-    @test gas3.T == 703.6767764998808
+    @test gas3.T ≈ 703.6767764998808 rtol = 1e-8
 
     @testset "tasopt comparisons" begin
         gas = Gas()


### PR DESCRIPTION
I find that the limit cycle issue persists, usually when the gas is at high temperature. For example, see
```
g = IdealGasThermo.Gas()
g.X = [0.009182717776831622, 0.0, 0.019776989870708743, 0.03892839790034769, 0.7656415748917463, 0.1664703195603657, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
g.T = 1000.0
g.h = 167966.47874122392
```
which fails even with the code to prevent limit cycles.

I suggest making the convergence criterion for the newton solver relative instead of absolute as it is now. This seems to solve the problem above. 