### PR TITLE
Release the pure core as 1.1.0 (additive), not a 2.0.0 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@ All notable changes to IdealGasThermo.jl are documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/); the project follows
 [Semantic Versioning](https://semver.org/).
 
-## [2.0.0-beta1] — 2026-06-19
+## [1.1.0] — 2026-06-19
 
-First public pre-release of `2.0.0`. The **immutable pure core is the headline
-API**; the legacy mutable layer is **loudly deprecated but fully working**. Nothing
-that was exported has been removed or renamed — this release is **safe to adopt and
-to migrate against**, and downstream packages can pin this tag (or its SHA) with
-confidence. The breaking removal of the legacy layer is deferred to `2.0.0` final
-(ADR-0007).
+A purely **additive** minor release over `1.0.0`: the immutable pure core becomes
+the headline API, and the legacy mutable layer is **loudly deprecated but fully
+working**. Nothing exported is removed or renamed — `1.1.0` is backward-compatible
+with `1.0.0` and **safe to adopt and migrate against**; downstream packages can pin
+this tag (or its SHA). The breaking removal of the legacy layer is deferred to a
+future **`2.0.0`** (ADR-0002, ADR-0007).
 
 ### Added
 
-The entire immutable pure core is **net-new** in v2 (it did not exist in any prior
-release). `using IdealGasThermo` now makes the following callable without
+The entire immutable pure core is **net-new** in this release (it did not exist in
+`1.0.0`). `using IdealGasThermo` now makes the following callable without
 qualification:
 
 - **`FrozenGas`** — the immutable, `isbits` substance: mass-specific NASA-9 property
@@ -67,7 +67,7 @@ qualification:
   `combustion.jl`, the mutable-turbo in `turbo.jl`, `thermoProps.jl`, and the
   `Gas`-based `print_thermo_table`). They still work; constructing a `Gas` or
   `Gas1D` now emits a **loud, once-per-session** deprecation warning. Scheduled for
-  deletion in `2.0.0` final (ADR-0002, ADR-0007).
+  removal in a future `2.0.0` (ADR-0002, ADR-0007).
 
   **Migration to the pure core:**
 
@@ -88,7 +88,7 @@ qualification:
 - **`DryAir` is now built directly from the `Xair` mole-fraction table**
   (`generate_composite_species(Xidict2Array(Xair), "Dry Air")`) instead of through
   `Gas()`. This cuts the last tie between the pure core and the legacy layer, so the
-  layer can be deleted in `2.0.0` final without touching any live path. The result is
+  layer can be removed in the future `2.0.0` without touching any live path. The result is
   identical to the previous construction to machine precision (molecular weight
   bit-equal; `cp` / `h` / `s0` agree to ~1e-14). No user-facing change.
 
@@ -111,15 +111,17 @@ qualification:
   per type per session. They are **not** `Base.depwarn`, so they are unaffected by
   the `--depwarn` flag (neither hidden by its default nor escalated to errors by
   `--depwarn=error`).
-- The pre-v2 test suite (the legacy `Gas` / `Gas1D` suite, 514 tests) runs unchanged
+- The `1.0.0` legacy test suite (the `Gas` / `Gas1D` suite, 514 tests) runs unchanged
   against this source and passes — no hard breaks, no numeric drift.
 
-## Prior releases
+## [1.0.0]
 
-The pre-v2 package was the mutable, stateful `Gas` / `Gas1D` convenience layer for
-NASA-9 thermodynamics; the immutable pure core did not yet exist. The last public
-tags were `v0.1`, `v0.1.1`, `v0.1.2`. (An untagged `1.0.0` exists in the pre-v2
-baseline's `Project.toml`, but it was never released — it is an internal version
-number of the same legacy-only package, not a public release of a pure core.)
+The mutable, stateful `Gas` / `Gas1D` convenience layer for NASA-9 thermodynamics —
+the baseline this `1.1.0` extends. The immutable pure core did not yet exist. This is
+the **sole version registered in the Julia General registry**, so `Pkg.add("IdealGasThermo")`
+installs it today. (General records `1.0.0` against a commit; the matching `v1.0.0`
+git tag was never pushed — TagBot did not run — so the repository shows only the
+earlier, hand-made `v0.1`, `v0.1.1`, `v0.1.2` tags, which were never registered.)
 
-[2.0.0-beta1]: https://github.com/MIT-LAE/IdealGasThermo.jl/releases/tag/v2.0.0-beta1
+[1.1.0]: https://github.com/MIT-LAE/IdealGasThermo.jl/releases/tag/v1.1.0
+[1.0.0]: https://github.com/MIT-LAE/IdealGasThermo.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IdealGasThermo"
 uuid = "d4fb33c0-2494-4384-b7a5-e5d0487b6649"
 authors = ["Prashanth Prakash <prash@mit.edu> and contributors"]
-version = "2.0.0-beta1"
+version = "1.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Pkg.add(url = "https://github.com/MIT-LAE/IdealGasThermo.jl")
 
 `using IdealGasThermo` to load it (the module name is `IdealGasThermo`, independent of the repository name).
 
-### v2.0 pre-release (beta)
+### v1.1 — the immutable pure core (additive)
 
-The `2.0.0-beta` series promotes the immutable pure core (`FrozenGas`, `GasState`, and the process/flow verbs) to the headline API and **loudly deprecates** the legacy mutable layer (`Gas`, `Gas1D`, and the functions they back), which is removed in `2.0.0` final. To pin a downstream project to a specific beta during migration, install by tag:
+`1.1.0` promotes the immutable pure core (`FrozenGas`, `GasState`, and the process/flow verbs) to the headline API and **loudly deprecates** the legacy mutable layer (`Gas`, `Gas1D`, and the functions they back). It is purely additive over `1.0.0` — nothing is removed — so it is safe to adopt and migrate against; the legacy layer is removed in a future `2.0.0`. Pin a downstream project by tag (or SHA):
 
 ```julia
 using Pkg
-Pkg.add(url = "https://github.com/MIT-LAE/IdealGasThermo.jl", rev = "v2.0.0-beta1")
+Pkg.add(url = "https://github.com/MIT-LAE/IdealGasThermo.jl", rev = "v1.1.0")
 ```
 
 See [`CHANGELOG.md`](CHANGELOG.md) for the migration mapping and [`docs/adr/0007-v2-deprecated-beta-migration.md`](docs/adr/0007-v2-deprecated-beta-migration.md) for the rationale.


### PR DESCRIPTION
The General registry holds one published version, `1.0.0` (the legacy `Gas`/`Gas1D` package; registered against a commit, with no matching git tag because TagBot never ran — which is why the repo shows only the hand-made `v0.1.x` tags). That makes `1.0.0` the real public baseline, and this release is **purely additive** over it: the immutable pure core is added, the legacy layer is deprecated-but-working, and nothing exported is removed. Under SemVer that is a MINOR bump → `1.1.0`, not a new major.

Changes:
- Project.toml: `version = "1.1.0"`.
- CHANGELOG: re-head the entry `[1.1.0]`, drop the pre-release framing, point the legacy removal at "a future `2.0.0`", and replace the incorrect "1.0.0 was never released" note with a real `[1.0.0]` entry recording it as the sole General-registered version (legacy-only).
- README: retitle the version section to v1.1 (additive) and pin `v1.1.0`.

Docs/metadata only — no source change; the test suite is unaffected. ADR-0007 and the `2.0.0-beta` mentions in CONTEXT.md still describe the old scheme and need a separate follow-up.