### PR TITLE
Make Vitiator reaction-only and accept a "live" oxidizer in products

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,18 +34,24 @@ terms exactly.
   not zero. Sensible enthalpy from 298.15 K is `h(gas, T) − h(gas, 298.15)`.
 - **Vitiated mixture** — combustion products of a fuel + oxidizer at a given
   **FAR** (fuel–air mass ratio), frozen composition, complete combustion.
-- **Vitiator** — a precomputed fuel + oxidizer combustion system, built once
-  from a fuel and an oxidizer; stores **only the reaction stoichiometry**
-  (`Xin`, `ΔX`, `massratio`, `ηburn`) — the NASA-9 lumping uses the shared
-  module-const basis. The pure, allocation-free replacement for the Dict-based
-  `vitiated_species` path on the hot path. Deliberately **not** named
+- **Vitiator** — a precomputed **fuel-reaction** system, built once from a fuel;
+  stores only the reaction stoichiometry (`MWfuel`, `ΔX`, `ηburn`) — the NASA-9
+  lumping uses the shared module-const basis. The oxidizer is an input to
+  `products`, so a fixed reaction can burn either dry air
+  (`products_in_air(sys, FAR)`) or a specific, possibly Dual-carrying,
+  `FrozenGas` (`products(sys, oxidizer, FAR)`) without reconstructing the system. The pure,
+  allocation-free replacement for the Dict-based `vitiated_species` path on the
+  hot path. Deliberately **not** named
   `Combustor`: that noun is reserved for the hardware component (pressure drop,
   efficiency, geometry) one abstraction level up in a cycle deck (ADR-0008).
   Construction is two methods: a `species` method does the work; the
   `AbstractString` method resolves the fuel name and forwards.
-- **products** — `products(sys::Vitiator, FAR) -> FrozenGas`: the
-  combustion-product gas at a given FAR. Pure, zero-allocation, smooth in
-  FAR (ForwardDiff through FAR works; `FrozenGas{TF}` widens its eltype).
+- **products** — `products(sys::Vitiator, oxidizer, FAR) -> FrozenGas`: the
+  combustion-product gas at a given fuel/oxidizer mass ratio. The hot path takes
+  a `FrozenGas` or database-ordered `SVector` oxidizer and is pure,
+  zero-allocation, and smooth in FAR and oxidizer composition (ForwardDiff
+  through either widens `FrozenGas{TF}`). `products_in_air(sys, FAR)` is the
+  dry-air convenience form.
 - **mix** — the merge of two gases, a free function (no precomputed system —
   each `FrozenGas` already carries its composition `X`); ADR-0008.
   - `mix(a::FrozenGas, b::FrozenGas, mratio) -> FrozenGas`: the merged
@@ -189,7 +195,7 @@ terms exactly.
   inversions — never by differentiating a Newton loop.
 - **Dual-carrying gas** — a `FrozenGas{<:Dual}`, i.e. a substance whose
   *coefficients themselves* carry a tangent, as produced by
-  `products(sys, FAR::Dual)` (the product composition depends on FAR, so the
+  `products_in_air(sys, FAR::Dual)` (the product composition depends on FAR, so the
   mass-scaled NASA-9 coefficients, MW, R, and Hf all carry the FAR-derivative).
   The parametric eltype `FrozenGas{TF<:Real}` is what makes this legal: a
   Dual-valued argument simply widens the gas. Forward property reads through a

--- a/docs/adr/0002-frozengas-is-the-architecture.md
+++ b/docs/adr/0002-frozengas-is-the-architecture.md
@@ -22,7 +22,7 @@ and does `FrozenGas` take over the name `Gas`?
 2. **`Gas{N}` is retained for now** — not as a thermodynamics hot path but
    as the *composition workspace* behind combustion, mixing, and humidity.
    It becomes removable only when pure FrozenGas-producing constructors
-   cover those jobs (`products(sys, FAR)`, frozen-gas mixing, humid-air
+   cover those jobs (`products_in_air(sys, FAR)`, frozen-gas mixing, humid-air
    construction). Once that layer lands, `Gas{N}` is demoted to an
    unexported interactive convenience or deprecated in turn.
 

--- a/docs/adr/0007-v2-deprecated-beta-migration.md
+++ b/docs/adr/0007-v2-deprecated-beta-migration.md
@@ -64,7 +64,7 @@ Retire the legacy layer in **two phases**, separated by a migration window:
    legacy-only smoke test files (`unit_test_turbo`, `unit_test_vitiated`,
    `unit_test_composite`, the legacy parts of `unit_test_mixthermo`). Replace the
    remaining `vitiated_species(...)` *fixtures* in `unit_test_mixing`/
-   `unit_test_properties` with `products(Vitiator(...), FAR)` (ADR-0006 §75). This
+   `unit_test_properties` with `products_in_air(Vitiator(...), FAR)` (ADR-0006 §75). This
    touches no pure-core oracle. Because the betas are pre-releases of `2.0.0`, `Gas`
    only ever exists in pre-release versions; the first *stable* 2.x release has it gone.
    **Before** deleting the legacy test files, two coverage items must be re-homed into

--- a/docs/adr/0008-composition-carrying-frozengas-and-mix.md
+++ b/docs/adr/0008-composition-carrying-frozengas-and-mix.md
@@ -44,7 +44,7 @@ Three further facts shaped the decision:
    (`cp`/`h`/`s0`, which never read `X`) is unchanged in speed and allocation.
    `products`/`mixed`/`humid_air` already computed `X` and threw it away; they now
    store it. For the AD path, `X` is naturally `Dual`-valued when produced by
-   `products(sys, FAR::Dual)` — the eltype `TF` widens with it, exactly as the
+   `products_in_air(sys, FAR::Dual)` — the eltype `TF` widens with it, exactly as the
    other fields already do.
 
 2. **Mixing is a free function `mix`, not a precomputed system.** Because each gas
@@ -111,7 +111,7 @@ Three further facts shaped the decision:
 ## Consequences
 
 - The internally-mixed-flow turbofan composes directly:
-  `mix(GasState(products(comb, FAR), T_core, P), GasState(FrozenGas(DryAir),
+  `mix(GasState(products_in_air(comb, FAR), T_core, P), GasState(FrozenGas(DryAir),
   T_bypass, P), BPR)` returns the energy-balanced mixed stagnation state, and the
   mixed gas's `X` feeds an afterburner `Vitiator` or another `mix`. The whole
   chain is zero-allocation and ForwardDiff-through-`FAR`/`mratio`.

--- a/docs/src/derivatives.md
+++ b/docs/src/derivatives.md
@@ -93,7 +93,7 @@ This is about **2× faster** than differentiating the loop and, more importantly
 ### Differentiating through composition
 
 When the composition itself depends on a parameter — as in
-`products(vit, FAR::Dual)`, where the burned-gas mole fractions are a function of
+`products(vit, air, FAR::Dual)`, where the burned-gas mole fractions are a function of
 the fuel–air ratio — the resulting `FrozenGas` *carries* the tangent in its own
 coefficients. The IFT rule then adds a "composition moves" term: the partials of
 ``h(\text{gas}, T^\star)`` with respect to the gas, obtained from a single forward
@@ -169,15 +169,15 @@ ForwardDiff.gradient(f, [288.15, 12.0])
 ```@example deriv
 # differentiate burned-gas enthalpy through combustion w.r.t. FAR —
 # the composition depends on FAR, handled by the Dual-carrying-gas rule
-vit = Vitiator("CH4", DryAir)
-ForwardDiff.derivative(far -> h(products(vit, far), 1500.0), 0.03)
+vit = Vitiator("CH4")
+ForwardDiff.derivative(far -> h(products(vit, air, far), 1500.0), 0.03)
 ```
 
 ```@example deriv
 # forward-property pushforward: BOTH composition AND temperature move with FAR.
-# One seed flows through products(vit, far) and through 1500 + 1e4·far together;
+# One seed flows through products(vit, air, far) and through 1500 + 1e4·far together;
 # the total derivative comes back as a single number (one-layer dual, not nested).
-g(far) = h(products(vit, far), 1500.0 + 1e4 * far)
+g(far) = h(products(vit, air, far), 1500.0 + 1e4 * far)
 (ad = ForwardDiff.derivative(g, 0.03),
  fd = (g(0.03 + 1e-6) - g(0.03 - 1e-6)) / 2e-6)
 ```

--- a/docs/src/tutorials/combustion.md
+++ b/docs/src/tutorials/combustion.md
@@ -6,8 +6,8 @@ run when the docs are built.
 
 ## Vitiated products
 
-A `Vitiator` is the *composition* model of combustion: build it **once** for a
-given fuel and oxidizer, then call `products(vit, FAR)` for any fuel–air ratio
+A `Vitiator` is the *reaction* model of combustion: build it **once** for a
+given fuel, then call `products(vit, oxidizer, FAR)` for any fuel/oxidizer ratio
 ``\mathrm{FAR}`` (by mass). It returns an immutable `FrozenGas` — the burned-gas
 substance — with no allocation. (We choose `Vitiator` because something like `Combustor` is 
 very likely to conflict with the use cases of this package)
@@ -15,8 +15,9 @@ very likely to conflict with the use cases of this package)
 ```@example comb
 using IdealGasThermo
 
-vit    = Vitiator("CH4", DryAir)     # methane burned in dry air, built once
-burned = products(vit, 0.03)         # FAR = 0.03 (lean)
+vit    = Vitiator("CH4")             # methane reaction, built once
+air    = FrozenDryAir                  # oxidizer
+burned = products(vit, air, 0.03)     # FAR = 0.03 (lean)
 
 (R = R(burned), cp_1500 = c_p(burned, 1500.0))
 ```
@@ -38,8 +39,8 @@ can differentiate through it — see [Thermodynamic derivatives](@ref derivative
 **composition** (each gas remembers its mole fractions):
 
 ```@example comb
-core   = products(vit, 0.03)         # hot combustion products
-bypass = FrozenGas(DryAir)           # cold bypass air
+core   = products(vit, air, 0.03)    # hot combustion products
+bypass = FrozenDryAir                # cold bypass air
 
 blend = mix(core, bypass, 5.0)       # 5 parts bypass per part core
 c_p(blend, 1000.0)

--- a/src/IdealGasThermo.jl
+++ b/src/IdealGasThermo.jl
@@ -51,7 +51,7 @@ export compress, expand, expand_to, add_heat, add_work, extract_work
 include("flow.jl")
 export speed_of_sound, mach, stagnation_state, static_state
 include("vitiator.jl")
-export Vitiator, products
+export Vitiator, products, products_in_air
 include("mix.jl")
 export mix
 include("atmosphere.jl")
@@ -64,6 +64,10 @@ include("atmosphere.jl")
 # to the old `let g=Gas(); g.X=Xair; … end` form to machine precision (MW bit-equal).
 const DryAir = generate_composite_species(Xidict2Array(Xair), "Dry Air")
 export DryAir
+# Default oxidizer backing `products_in_air(sys, FAR)`. `Vitiator` itself is
+# reaction-only; `products` always receives its oxidizer explicitly.
+const FrozenDryAir = FrozenGas(DryAir)
+export FrozenDryAir
 include("humidity.jl")
 export humid_air
 

--- a/src/vitiator.jl
+++ b/src/vitiator.jl
@@ -1,59 +1,50 @@
 """
     Vitiator
 
-Precomputed fuel + oxidizer combustion system: given a fuel–air ratio it
-produces the vitiated combustion-product gas via [`products`](@ref). The
-pure, allocation-free replacement for the Dict-based [`vitiated_species`](@ref)
-path.
+Precomputed fuel-reaction system: given an oxidizer composition and a fuel
+mass ratio, it produces the vitiated combustion-product gas via
+[`products`](@ref). The pure, allocation-free replacement for the Dict-based
+[`vitiated_species`] path.
 
-Built **once** from a fuel and an oxidizer (construction may consult the
-global species database `spdict`; [`products`](@ref) calls never do).
-Construction resolves the oxidizer composition and the per-mole-of-fuel
+Built **once** from a fuel (construction may consult the global species database
+`spdict`; [`products`](@ref) calls never do). It stores only the per-mole-of-fuel
 composition change for complete combustion (scaled by the burner efficiency
-`ηburn`), and stores **only that reaction stoichiometry** — the NASA-9 mixture
-lumping uses the shared module-const basis (`SPALOW`/…), not a per-system copy.
+`ηburn`) and the fuel molecular weight. The oxidizer is always an explicit
+input to `products`, allowing a changing upstream composition to carry a
+derivative without rebuilding the reaction system.
 
 This is the *composition* model of combustion; it is deliberately **not** named
 `Combustor`. That noun belongs to the hardware component in a cycle deck
 (pressure drop, efficiency map, geometry) so this layer leaves it free.
 
 ```julia-repl
-julia> sys = Vitiator("CH4", DryAir);
+julia> sys = Vitiator("CH4");
 
-julia> gas = products(sys, 0.03); # FrozenGas of the burnt mixture
+julia> gas = products(sys, FrozenDryAir, 0.03);
 ```
-
-Accepted oxidizer forms: a [`composite_species`](@ref) (e.g. `DryAir`), a
-database [`species`](@ref) or its name (`"Air"` maps to the dry-air
-composition `Xair`, mirroring the legacy path), a mole-fraction
-`Dict{String,Float64}`, or a mole-fraction vector ordered as `spdict`.
 """
 struct Vitiator
     name::String
     ηburn::Float64                               # burner efficiency [-]
-    massratio::Float64                           # MW_ox / MW_fuel [-]
+    MWfuel::Float64                              # fuel molecular weight [g/mol]
     sumΔX::Float64                               # net mole change per mole fuel [-]
-    Xin::SVector{Nspecies,Float64}               # oxidizer mole fractions (Σ = 1)
     ΔX::SVector{Nspecies,Float64}                # mole change per mole fuel
 end
 
 """
-    Vitiator(fuel, oxidizer=DryAir; ηburn=1.0)
+    Vitiator(fuel; ηburn=1.0)
 
-Construct the precomputed combustion system for `fuel`
-(an `AbstractString` name or a [`species`](@ref)) burning in `oxidizer`
-(see [`Vitiator`](@ref) for accepted forms) with burner efficiency
-`ηburn` (fraction of fuel burnt; the remainder appears unreacted in the
-products). Allocates and consults the species database — do this once,
-outside the hot path. The `AbstractString` form resolves the fuel name and
-forwards to the `species` method.
+Construct the precomputed fuel-reaction system for `fuel` (an `AbstractString`
+name or a [`species`](@ref)) with burner efficiency `ηburn`. The oxidizer belongs
+to [`products`](@ref), not the system: use `products(sys, oxidizer, FAR)`, or
+[`products_in_air`](@ref) for the dry-air convenience. Construction allocates and
+consults the species database — do this once, outside the hot path. The
+`AbstractString` form resolves the fuel name and forwards to the `species` method.
 """
-Vitiator(fuel::AbstractString, oxidizer = DryAir; ηburn::Float64 = 1.0) =
-    Vitiator(species_in_spdict(fuel), oxidizer; ηburn = ηburn)
+Vitiator(fuel::AbstractString; ηburn::Float64 = 1.0) =
+    Vitiator(species_in_spdict(fuel); ηburn = ηburn)
 
-function Vitiator(fuel::species, oxidizer = DryAir; ηburn::Float64 = 1.0)
-    Xin, MWox = _X_MW(oxidizer)
-
+function Vitiator(fuel::species; ηburn::Float64 = 1.0)
     # Per-mole-of-fuel composition change, scaled by ηburn; unburnt fuel
     # passes through (mirrors vitiated_mixture).
     nCO2, nN2, nH2O, nO2 = ηburn .* reaction_change_molar_fraction(fuel.name)
@@ -66,22 +57,36 @@ function Vitiator(fuel::species, oxidizer = DryAir; ηburn::Float64 = 1.0)
     ΔX[findfirst(==("O2"), names)] += nO2
 
     Vitiator(
-        "$(fuel.name) + $(oxidizer isa AbstractSpecies ? oxidizer.name : "oxidizer")",
+        "$(fuel.name) reaction",
         ηburn,
-        MWox / fuel.MW,
+        fuel.MW,
         sum(ΔX),
-        SVector{Nspecies,Float64}(Xin),
         SVector{Nspecies,Float64}(ΔX),
     )
 end
 
 """
-    products(sys::Vitiator, FAR) -> FrozenGas
+    products_in_air(sys::Vitiator, FAR) -> FrozenGas
 
-Combustion-product [`FrozenGas`](@ref) of the system `sys` at fuel–air
-(mass) ratio `FAR`. Pure function of `(sys, FAR)`: zero allocations,
-no global lookups, smooth in `FAR` and generic over `Real` (ForwardDiff
-through `FAR` works).
+Dry-air convenience for [`products`](@ref): equivalent to
+`products(sys, FrozenDryAir, FAR)`. Use it only when dry air is the
+intended oxidizer; [`products`](@ref) itself always takes an oxidizer explicitly.
+"""
+products_in_air(sys::Vitiator, FAR) = products(sys, FrozenDryAir, FAR)
+
+"""
+    products(sys::Vitiator, oxidizer, FAR) -> FrozenGas
+
+Combustion-product [`FrozenGas`](@ref) from the fuel reaction `sys`, oxidizer,
+and fuel/oxidizer mass ratio `FAR`. The function is pure and generic over
+`Real`: FAR and/or oxidizer composition can carry ForwardDiff tangents. Its
+zero-allocation hot paths accept a [`FrozenGas`] or database-ordered `SVector`
+oxidizer. An `AbstractVector` convenience method converts to that static-vector
+kernel; use [`products_in_air`](@ref) when dry air is intended.
+
+The three-argument form derives the oxidizer molecular weight and composition
+from its live input, so a changing upstream composition can carry a ForwardDiff
+tangent without constructing a new reaction system.
 
 The product composition is
 `X(FAR) = (Xin + molFAR·ΔX) / (1 + molFAR·ΣΔX)` with
@@ -92,10 +97,23 @@ by `1000/MW` — identical (to rounding) to
 `FrozenGas(vitiated_species(fuel, oxidizer, FAR))`. Same formation-inclusive
 enthalpy datum as every `FrozenGas`.
 """
-function products(sys::Vitiator, FAR)
-    molFAR = FAR * sys.massratio
-    X = (sys.Xin + molFAR * sys.ΔX) / (1 + molFAR * sys.sumΔX)
+function products(sys::Vitiator, Xin::AbstractVector{TX}, FAR) where {TX<:Real}
+    products(sys, SVector{Nspecies,TX}(Xin), FAR)
+end
+
+function products(sys::Vitiator, Xin::SVector{Nspecies,TX}, FAR) where {TX<:Real}
+    Xoxidizer = Xin / sum(Xin)
+    molFAR = FAR * dot(SPMW, Xoxidizer) / sys.MWfuel
+    X = (Xoxidizer + molFAR * sys.ΔX) / (1 + molFAR * sys.sumΔX)
     FrozenGas(X)   # the lumping (basis × X + entropy of mixing) lives in FrozenGas
+end
+
+# A FrozenGas is already normalized and stores its molecular weight, so the
+# live re-burn path avoids redoing the generic SVector input normalization.
+function products(sys::Vitiator, oxidizer::FrozenGas, FAR)
+    molFAR = FAR * oxidizer.MW / sys.MWfuel
+    X = (oxidizer.X + molFAR * sys.ΔX) / (1 + molFAR * sys.sumΔX)
+    FrozenGas(X)
 end
 
 # ── Combustion stoichiometry ──────────────────────────────────────────────────

--- a/test/unit_test_flow.jl
+++ b/test/unit_test_flow.jl
@@ -123,15 +123,15 @@ using ForwardDiff
         # IFT rule and return a single-layer Dual. (The other GasState accessors
         # are plain delegations, covered by the dual-gas property tests.)
         D = ForwardDiff.derivative
-        vit = Vitiator("CH4", DryAir)
+        vit = Vitiator("CH4")
         far0, M = 0.03, 0.8
         δ = 1e-6
         fd(f) = (f(far0 + δ) - f(far0 - δ)) / 2δ
-        stag(far) = stagnation_state(GasState(products(vit, far), 1500.0, 8e5), M).T
-        stat(far) = static_state(GasState(products(vit, far), 1500.0, 8e5), M).T
+        stag(far) = stagnation_state(GasState(products_in_air(vit, far), 1500.0, 8e5), M).T
+        stat(far) = static_state(GasState(products_in_air(vit, far), 1500.0, 8e5), M).T
         # single-layer, not the nested Dual the constant-substance rule would give
         # (the value-only ≈ check below can pass on a nested result, so pin the type)
-        Sd = GasState(products(vit, ForwardDiff.Dual{:far}(far0, 1.0)), 1500.0, 8e5)
+        Sd = GasState(products_in_air(vit, ForwardDiff.Dual{:far}(far0, 1.0)), 1500.0, 8e5)
         @test stagnation_state(Sd, M).T isa ForwardDiff.Dual{:far,Float64,1}
         @test D(stag, far0) ≈ fd(stag) rtol = 1e-6
         @test D(stat, far0) ≈ fd(stat) rtol = 1e-6

--- a/test/unit_test_frozengas.jl
+++ b/test/unit_test_frozengas.jl
@@ -162,8 +162,8 @@ using ForwardDiff
 
         # Dual-carrying gas × same-tag Dual T: forward properties stay zero-allocation
         # (h as the representative primitive, props as the compound, matching above)
-        let vit = Vitiator("CH4", DryAir),
-            gasd = products(vit, ForwardDiff.Dual{:t}(0.03, 1.0)),
+        let vit = Vitiator("CH4"),
+            gasd = products_in_air(vit, ForwardDiff.Dual{:t}(0.03, 1.0)),
             Td   = ForwardDiff.Dual{:t}(1600.0, 1.0)
             @test (@ballocated IdealGasThermo.h($gasd, $Td) samples = 1 evals = 1) == 0
             @test (@ballocated props($gasd, $Td) samples = 1 evals = 1) == 0
@@ -202,7 +202,7 @@ using ForwardDiff
         @test IdealGasThermo.cp(rebuilt, 800.0) ≈ IdealGasThermo.cp(air, 800.0) rtol = 1e-14
 
         # FAR-carrying products expose the (Dual-valued) composition too
-        p = products(Vitiator("CH4", DryAir), 0.03)
+        p = products_in_air(Vitiator("CH4"), 0.03)
         @test sum(p.X) ≈ 1.0
     end
 

--- a/test/unit_test_mixing.jl
+++ b/test/unit_test_mixing.jl
@@ -25,7 +25,7 @@ using ForwardDiff
 
     @testset "energy balance: adiabatic mix conserves total enthalpy" begin
         P = 2.5e5
-        core = GasState(products(Vitiator("CH4", DryAir), 0.03), 1500.0, P)
+        core = GasState(products_in_air(Vitiator("CH4"), 0.03), 1500.0, P)
         bypass = GasState(FrozenGas(DryAir), 320.0, P)
         BPR = 5.0
         m = mix(core, bypass, BPR)

--- a/test/unit_test_products.jl
+++ b/test/unit_test_products.jl
@@ -60,12 +60,25 @@ using ForwardDiff
         h_product(o2) = IdealGasThermo.h(products(sys, oxidizer(o2), 0.02), 1600.0)
         d_ad = ForwardDiff.derivative(h_product, o2_0)
         δ = 1e-6
-        d_fd = (h_product(o2_0 + δ) - h_product(o2_0 - δ)) / (2δ)
-        @test d_ad ≈ d_fd rtol = 1e-6
+        d_fd_o2 = (h_product(o2_0 + δ) - h_product(o2_0 - δ)) / (2δ)
+        @test d_ad ≈ d_fd_o2 rtol = 1e-6
+
+        # The same derivative path occurs when a physical upstream mixer
+        # supplies the oxidizer. `mix` returns a FrozenGas whose composition
+        # follows `mratio`; products must preserve that tangent without
+        # rebuilding the fuel reaction system.
+        co2 = FrozenGas(species_in_spdict("CO2"))
+        h_mixed_oxidizer(mratio) =
+            IdealGasThermo.h(products(sys, mix(air, co2, mratio), 0.02), 1600.0)
+        mratio = 0.05
+        d_ad = ForwardDiff.derivative(h_mixed_oxidizer, mratio)
+        d_fd_mixed =
+            (h_mixed_oxidizer(mratio + δ) - h_mixed_oxidizer(mratio - δ)) / (2δ)
+        @test d_ad ≈ d_fd_mixed rtol = 1e-6
 
         h_product_vector(o2) =
             IdealGasThermo.h(products(sys, collect(oxidizer(o2)), 0.02), 1600.0)
-        @test ForwardDiff.derivative(h_product_vector, o2_0) ≈ d_fd rtol = 1e-6
+        @test ForwardDiff.derivative(h_product_vector, o2_0) ≈ d_fd_o2 rtol = 1e-6
 
         Xdual = oxidizer(ForwardDiff.Dual{:oxidizer}(o2_0, 1.0))
         @test eltype(products(sys, Xdual, 0.02).X) <: ForwardDiff.Dual
@@ -80,6 +93,15 @@ using ForwardDiff
             products(sys, products_in_air(upstream, far), 0.005), 1600.0)
         d_ad = ForwardDiff.derivative(h_reburn, 0.01)
         d_fd = (h_reburn(0.01 + δ) - h_reburn(0.01 - δ)) / (2δ)
+        @test d_ad ≈ d_fd rtol = 1e-6
+
+        # A downstream burner may use a different fuel. Each Vitiator can be
+        # constructed once, then consume the live product gas from upstream.
+        downstream = Vitiator("H2")
+        h_two_fuel_burners(far) = IdealGasThermo.h(
+            products(downstream, products_in_air(upstream, far), 0.005), 1600.0)
+        d_ad = ForwardDiff.derivative(h_two_fuel_burners, 0.01)
+        d_fd = (h_two_fuel_burners(0.01 + δ) - h_two_fuel_burners(0.01 - δ)) / (2δ)
         @test d_ad ≈ d_fd rtol = 1e-6
     end
 

--- a/test/unit_test_products.jl
+++ b/test/unit_test_products.jl
@@ -3,34 +3,84 @@ using ForwardDiff
 @testset "Vitiator products" begin
 
     @testset "FAR = 0 reproduces the oxidizer" begin
-        sys = Vitiator("CH4", DryAir)
-        air = FrozenGas(DryAir)
-        gas0 = products(sys, 0.0)
+        sys = Vitiator("CH4")
+        @test fieldnames(Vitiator) == (:name, :ηburn, :MWfuel, :sumΔX, :ΔX)
+        @test_throws MethodError products(sys, 0.0)
+        air = FrozenDryAir
+        gas0 = products_in_air(sys, 0.0)
         @test gas0 isa FrozenGas
         for T in [300.0, 1600.0]
             @test IdealGasThermo.cp(gas0, T) ≈ IdealGasThermo.cp(air, T) rtol = 1e-10
             @test IdealGasThermo.h(gas0, T) ≈ IdealGasThermo.h(air, T) rtol = 1e-10
             @test IdealGasThermo.s0(gas0, T) ≈ IdealGasThermo.s0(air, T) rtol = 1e-10
         end
+
+        # The reaction carries no oxidizer: an explicit non-air oxidizer is
+        # reproduced at FAR = 0 as well.
+        n2 = FrozenGas(species_in_spdict("N2"))
+        @test products(sys, n2, 0.0).X == n2.X
     end
 
     @testset "zero allocations after warmup" begin
-        sys = Vitiator("CH4", "Air")
-        @test (@ballocated products($sys, 0.03) samples = 1 evals = 1) == 0
+        sys = Vitiator("CH4")
+        @test (@ballocated products_in_air($sys, 0.03) samples = 1 evals = 1) == 0
         # composed with a property read, still allocation-free
-        h_at(sys, FAR, T) = IdealGasThermo.h(products(sys, FAR), T)
+        h_at(sys, FAR, T) = IdealGasThermo.h(products_in_air(sys, FAR), T)
         @test (@ballocated $h_at($sys, 0.03, 1600.0) samples = 1 evals = 1) == 0
     end
 
     @testset "FAR-differentiability" begin
-        sys = Vitiator("CH4", "Air")
+        sys = Vitiator("CH4")
         D = ForwardDiff.derivative
-        h_at(far) = IdealGasThermo.h(products(sys, far), 1600.0)
+        h_at(far) = IdealGasThermo.h(products_in_air(sys, far), 1600.0)
         far = 0.03
         dh_ad = D(h_at, far)
         δ = 1e-6
         dh_fd = (h_at(far + δ) - h_at(far - δ)) / (2δ)
         @test dh_ad ≈ dh_fd rtol = 1e-6
+    end
+
+    @testset "oxidizer-composition differentiability" begin
+        # A general re-burn may receive an oxidizer composition derived from an
+        # upstream solve. Its tangent must reach the products' properties through
+        # the live oxidizer argument; a same-fuel cumulative-FAR afterburner uses
+        # one fixed system instead and does not need this path.
+        air = FrozenGas(DryAir)
+        iO2 = findfirst(==("O2"), IdealGasThermo.spdict.name)
+        iN2 = findfirst(==("N2"), IdealGasThermo.spdict.name)
+        o2_0 = air.X[iO2]
+
+        function oxidizer(o2)
+            X = map(x -> x + zero(o2), air.X) # promote the composition rail
+            X = Base.setindex(X, o2, iO2)
+            Base.setindex(X, air.X[iN2] + o2_0 - o2, iN2)
+        end
+
+        sys = Vitiator("CH4")
+        h_product(o2) = IdealGasThermo.h(products(sys, oxidizer(o2), 0.02), 1600.0)
+        d_ad = ForwardDiff.derivative(h_product, o2_0)
+        δ = 1e-6
+        d_fd = (h_product(o2_0 + δ) - h_product(o2_0 - δ)) / (2δ)
+        @test d_ad ≈ d_fd rtol = 1e-6
+
+        h_product_vector(o2) =
+            IdealGasThermo.h(products(sys, collect(oxidizer(o2)), 0.02), 1600.0)
+        @test ForwardDiff.derivative(h_product_vector, o2_0) ≈ d_fd rtol = 1e-6
+
+        Xdual = oxidizer(ForwardDiff.Dual{:oxidizer}(o2_0, 1.0))
+        @test eltype(products(sys, Xdual, 0.02).X) <: ForwardDiff.Dual
+        @test eltype(products(sys, collect(Xdual), 0.02).X) <: ForwardDiff.Dual
+        @test (@ballocated products($sys, $Xdual, 0.02) samples = 1 evals = 1) == 0
+        @test products(sys, FrozenDryAir, 0.02).X ≈ products_in_air(sys, 0.02).X
+
+        # The concrete re-burn shape: the oxidizer is itself a product gas
+        # whose composition moves with an upstream FAR.
+        upstream = Vitiator("CH4")
+        h_reburn(far) = IdealGasThermo.h(
+            products(sys, products_in_air(upstream, far), 0.005), 1600.0)
+        d_ad = ForwardDiff.derivative(h_reburn, 0.01)
+        d_fd = (h_reburn(0.01 + δ) - h_reburn(0.01 - δ)) / (2δ)
+        @test d_ad ≈ d_fd rtol = 1e-6
     end
 
     @testset "incomplete combustion (ηburn ≠ 1)" begin
@@ -40,16 +90,16 @@ using ForwardDiff
         # two gases must have measurably different properties. (Self-contained;
         # no comparison to the legacy vitiated_species path.)
         FAR = 0.03
-        full = products(Vitiator("CH4", "Air"; ηburn = 1.0), FAR)
-        partial = products(Vitiator("CH4", "Air"; ηburn = 0.9), FAR)
+        full = products_in_air(Vitiator("CH4"; ηburn = 1.0), FAR)
+        partial = products_in_air(Vitiator("CH4"; ηburn = 0.9), FAR)
         # the compositions differ ⟹ cp differs by well over numerical noise
         @test !isapprox(IdealGasThermo.cp(partial, 1600.0),
                         IdealGasThermo.cp(full, 1600.0); rtol = 1e-3)
         # and ηburn has no effect when there is no fuel to burn: at FAR = 0 both
         # collapse to the pure oxidizer regardless of ηburn
-        air = FrozenGas(DryAir)
+        air = FrozenDryAir
         for ηburn in (0.9, 1.0)
-            gas0 = products(Vitiator("CH4", DryAir; ηburn = ηburn), 0.0)
+            gas0 = products_in_air(Vitiator("CH4"; ηburn = ηburn), 0.0)
             @test IdealGasThermo.cp(gas0, 1600.0) ≈ IdealGasThermo.cp(air, 1600.0) rtol = 1e-10
         end
     end

--- a/test/unit_test_properties.jl
+++ b/test/unit_test_properties.jl
@@ -12,16 +12,16 @@ using ForwardDiff
     uni(a, b) = a + (b - a) * rand(rng) #uniform random between a and b
 
     air = FrozenGas(DryAir)
-    sysCH4 = Vitiator("CH4", DryAir)
-    sysJet = Vitiator("Jet-A(g)", DryAir)
+    sysCH4 = Vitiator("CH4")
+    sysJet = Vitiator("Jet-A(g)")
     vit = IdealGasThermo.vitiated_species("CH4", "Air", 0.04)
 
     # a small pool of randomly-parameterized gases spanning what the
     # constructors can produce
     gas_pool() = [
         air,
-        products(sysCH4, uni(0.005, 0.05)),
-        products(sysJet, uni(0.005, 0.045)),
+        products_in_air(sysCH4, uni(0.005, 0.05)),
+        products_in_air(sysJet, uni(0.005, 0.045)),
         mix(FrozenGas(DryAir), FrozenGas(vit), uni(0.1, 10.0)),
         humid_air(SH = uni(0.001, 0.05)),
     ]
@@ -82,7 +82,7 @@ using ForwardDiff
             ΣΔX = sum(IdealGasThermo.reaction_change_molar_fraction(fuel))
             for _ = 1:3
                 f = uni(0.005, FARmax)
-                gp = products(sys, f)
+                gp = products_in_air(sys, f)
                 # mass conservation through the mole-fraction algebra:
                 # (1 + molFAR·ΣΔX)·MW_products = MW_ox + molFAR·MW_fuel
                 molFAR = f * DryAir.MW / fsp.MW
@@ -97,7 +97,7 @@ using ForwardDiff
             fgas = FrozenGas(fsp)
             release =
                 -(
-                    (1 + f) * IdealGasThermo.h(products(sys, f), 298.15) -
+                    (1 + f) * IdealGasThermo.h(products_in_air(sys, f), 298.15) -
                     IdealGasThermo.h(air, 298.15) - f * IdealGasThermo.h(fgas, 298.15)
                 )
             @test release ≈ f * IdealGasThermo.LHV(fsp) rtol = 1e-5
@@ -162,7 +162,7 @@ using ForwardDiff
                 (i == 0 || i == n ? 1 : iseven(i) ? 2 : 4) * f(a + (b - a) * i / n)
                 for i = 0:n
             )
-        cases = [(air, 300.0, 800.0), (products(sysJet, 0.03), 700.0, 1500.0)]
+        cases = [(air, 300.0, 800.0), (products_in_air(sysJet, 0.03), 700.0, 1500.0)]
         push!(cases, (gas_pool()[end], uni(250.0, 900.0), uni(1100.0, 2200.0)))
         for (gas, T1, T2) in cases
             ∫cp = simpson(T -> IdealGasThermo.cp(gas, T), T1, T2, 2048)
@@ -182,11 +182,11 @@ using ForwardDiff
         @test_throws ErrorException T_from_h(air, 1.0e12)
         # beyond-stoichiometric FAR would need negative O2 — errors loudly
         # rather than returning an unphysical composition
-        @test_throws DomainError products(sysCH4, 0.5)
+        @test_throws DomainError products_in_air(sysCH4, 0.5)
     end
 
     @testset "Dual-carrying gas: AD inversions match finite differences" begin
-        # products(sys, FAR::Dual) yields a FrozenGas{<:Dual} whose coefficients
+        # products_in_air(sys, FAR::Dual) yields a FrozenGas{<:Dual} whose coefficients
         # carry the FAR-tangent, so inverting through it exercises the full
         # three-term IFT rule (the "composition moves" term). The invariant that
         # actually defines the rule's correctness — independent of fuel, oxidizer
@@ -199,7 +199,7 @@ using ForwardDiff
         δ = 1e-6
         fdcheck(f, x) = (f(x + δ) - f(x - δ)) / (2δ)
         for fuel in ["CH4", "H2", "Jet-A(g)"]   # distinct C/H/O ⟹ distinct ∂X/∂FAR
-            sys = Vitiator(fuel, DryAir)
+            sys = Vitiator(fuel)
             fsp = species_in_spdict(fuel)
             hF = 1000 * fsp.Hf / fsp.MW
             # Stay sub-stoichiometric for the leanest-ceiling fuel in the pool
@@ -209,39 +209,39 @@ using ForwardDiff
 
             # (1) burner energy balance: Dual gas + Dual target
             hA = IdealGasThermo.h(air, uni(500.0, 900.0))
-            T4of(far) = T_from_h(products(sys, far), (hA + far * hF) / (1 + far))
+            T4of(far) = T_from_h(products_in_air(sys, far), (hA + far * hF) / (1 + far))
             d1 = D(T4of, FAR0)
             @test d1 isa Real                       # not a nested Dual
             @test d1 ≈ fdcheck(T4of, FAR0) rtol = 1e-6
 
             # (2) Dual gas + plain-Float target: invert a moving gas to fixed h
-            hfix = IdealGasThermo.h(products(sys, FAR0), uni(1200.0, 1900.0))
-            Tfix(far) = T_from_h(products(sys, far), hfix)
+            hfix = IdealGasThermo.h(products_in_air(sys, FAR0), uni(1200.0, 1900.0))
+            Tfix(far) = T_from_h(products_in_air(sys, far), hfix)
             @test D(Tfix, FAR0) ≈ fdcheck(Tfix, FAR0) rtol = 1e-6
 
             # (3) Dual gas through the isentropic inversion
             T1, PR = uni(1100.0, 1500.0), uni(2.0, 10.0)
-            Tisen(far) = IdealGasThermo._T_polytropic(products(sys, far), T1, PR)
+            Tisen(far) = IdealGasThermo._T_polytropic(products_in_air(sys, far), T1, PR)
             @test D(Tisen, FAR0) ≈ fdcheck(Tisen, FAR0) rtol = 1e-6
         end
     end
 
     @testset "Dual-carrying gas: AD forward properties match finite differences" begin
-        # products(sys, FAR::Dual) yields a FrozenGas{<:Dual} whose coefficients
+        # products_in_air(sys, FAR::Dual) yields a FrozenGas{<:Dual} whose coefficients
         # carry the FAR-tangent. When T is also a same-tag Dual, both composition
         # and temperature move with one seed and the total derivative is the sum
         # of the composition tangent and the temperature tangent. As for the
         # inversions, the fuel/oxidizer-independent invariant is AD == central FD;
-        # seeding a single ξ through both products(sys, FAR0+ξ) and T0+ξ is exactly
+        # seeding a single ξ through both products_in_air(sys, FAR0+ξ) and T0+ξ is exactly
         # the same-tag Dual-gas-at-Dual-T path PowerCycles exercises.
         D = ForwardDiff.derivative
         δ = 1e-6
         fdcheck(f) = (f(δ) - f(-δ)) / (2δ)
         for fuel in ["CH4", "H2", "Jet-A(g)"]   # distinct C/H/O ⟹ distinct ∂X/∂FAR
-            sys  = Vitiator(fuel, DryAir)
+            sys  = Vitiator(fuel)
             FAR0 = uni(0.005, 0.02)             # sub-stoichiometric (H2 ceiling ≈ 0.029)
             T0   = uni(900.0, 1800.0)
-            gasf(ξ) = products(sys, FAR0 + ξ)   # composition moves with the seed…
+            gasf(ξ) = products_in_air(sys, FAR0 + ξ) # composition moves with the seed…
             # …and T with it. h/cp/s0/props are the new rules; gamma/speed_of_sound/
             # pressure_ratio carry none of their own and must inherit the total
             # derivative through generic dispatch.
@@ -266,7 +266,7 @@ using ForwardDiff
         # Jacobian assembly — and the value-only ≈ check above can pass on it — so
         # pin the concrete type directly. It is fuel-invariant, so assert it once.
         tag    = :fwdtype
-        gasd   = products(Vitiator("CH4", DryAir), ForwardDiff.Dual{tag}(0.012, 1.0))
+        gasd   = products_in_air(Vitiator("CH4"), ForwardDiff.Dual{tag}(0.012, 1.0))
         Td     = ForwardDiff.Dual{tag}(1500.0, 1.0)
         prd    = props(gasd, Td)
         single = ForwardDiff.Dual{tag,Float64,1}
@@ -284,7 +284,7 @@ using ForwardDiff
         # not the same-tag bug — the new rules must leave it nested: the gas has
         # tag :inner and h(gas, value(T)) is itself a Dual{:inner}, so the value
         # rail of the result is correctly a Dual{:inner}.
-        gas_inner = products(Vitiator("CH4", DryAir), ForwardDiff.Dual{:inner}(0.03, 1.0))
+        gas_inner = products_in_air(Vitiator("CH4"), ForwardDiff.Dual{:inner}(0.03, 1.0))
         T_outer   = ForwardDiff.Dual{:outer}(1600.0, 1.0)
         @test ForwardDiff.value(IdealGasThermo.h(gas_inner, T_outer)) isa ForwardDiff.Dual{:inner}
     end


### PR DESCRIPTION
`Vitiator` represents the fixed fuel reaction, while `products` receives the
oxidizer at the point of use:

```julia
sys = Vitiator("CH4")
gas = products(sys, oxidizer, FAR)
```
`products_in_air(sys, FAR)` provides the explicit dry-air convenience.

The main rationale is that the fuel reaction and burner efficiency are fixed once the Vitiator is constructed. The oxidizer composition is free to change if you had an upstream mixer, a humidifier, or some other prior combustor that may change it. Keeping the oxidizer out of the Vitiator allows the system to be constructed once and then reused as that upstream state changes. 

Running a quick benchmark on my computer suggested that this has no material difference in performance for the baseline case where it had fixed composition but a 4-6x faster performance when the upstream oxidizer changes.